### PR TITLE
Added pagination to GET /api/articles

### DIFF
--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -184,7 +184,7 @@ describe("/api/articles", () => {
             .get("/api/articles")
             .expect(200)
             .then((response) => {
-                expect(response.body.articles.length).toBe(13)
+                expect(response.body.articles.length).toBe(10)
                 response.body.articles.forEach((article) => {
                     expect(typeof article.article_id).toBe("number")
                     expect(typeof article.author).toBe("string")
@@ -283,10 +283,10 @@ describe("/api/articles", () => {
             })
             test("200: Filters articles by given topic when given a valid topic query", () => {
                 return request(app)
-                .get("/api/articles?topic=mitch")
+                .get("/api/articles?topic=cats")
                 .expect(200)
                 .then((response) => {
-                    expect(response.body.articles.length).toBe(12)
+                    expect(response.body.articles.length).toBe(1)
                     response.body.articles.forEach((article) => {
                         expect(typeof article.article_id).toBe("number")
                         expect(typeof article.author).toBe("string")
@@ -295,13 +295,65 @@ describe("/api/articles", () => {
                         expect(typeof article.votes).toBe("number")
                         expect(typeof article.article_img_url).toBe("string")
                         expect(typeof article.comment_count).toBe("number")
-                        expect(article.topic).toBe("mitch")
+                        expect(article.topic).toBe("cats")
                     })
                 })
             })
             test("200: Responds with an empty array when given a topic that exists but has no articles", () => {
                 return request(app)
                 .get("/api/articles?topic=paper")
+                .expect(200)
+                .then((response) => {
+                    expect(response.body.articles.length).toBe(0)
+                })
+            })
+            test("200: Responds with the correct number of articles sorted in the correct order when given a limit", () => {
+                return request(app)
+                .get("/api/articles?limit=5")
+                .expect(200)
+                .then((response) => {
+                    expect(response.body.articles.length).toBe(5)
+                    response.body.articles.forEach((article) => {
+                        expect(typeof article.article_id).toBe("number")
+                        expect(typeof article.author).toBe("string")
+                        expect(typeof article.title).toBe("string")
+                        expect(typeof article.created_at).toBe("string")
+                        expect(typeof article.votes).toBe("number")
+                        expect(typeof article.article_img_url).toBe("string")
+                        expect(typeof article.comment_count).toBe("number")
+                        expect(typeof article.topic).toBe("string")
+                    })
+                })
+            })
+            test("200: Responds with the correct number of articles starting from the correct position when given a page number using default limit", () => {
+                return request(app)
+                .get("/api/articles?&p=2")
+                .expect(200)
+                .then((response) => {
+                    expect(response.body.articles.length).toBe(3)
+                    return Promise.all([response.body.articles, db.query("SELECT * FROM articles ORDER BY created_at DESC")])
+                }).then(([articles, data]) => {
+                    data.rows.slice(10,13).forEach((article, index) => {
+                        expect(article.article_id).toBe(articles[index].article_id)
+                    })
+                })
+            })
+            test("200: Responds with the correct number of articles starting from the correct position when given a page number and limit", () => {
+                return request(app)
+                .get("/api/articles?limit=5&p=2")
+                .expect(200)
+                .then((response) => {
+                    expect(response.body.articles.length).toBe(5)
+                    return Promise.all([response.body.articles, db.query("SELECT * FROM articles ORDER BY created_at DESC")])
+                }).then(([articles, data]) => {
+                    data.rows.slice(5,10).forEach((article, index) => {
+                        expect(article.article_id).toBe(articles[index].article_id)
+                    })
+                })
+            })
+            test("200: Responds with an empty array when page number exceeds the maximum possible number of pages", () => {
+                return request(app)
+                .get("/api/articles?p=3")
                 .expect(200)
                 .then((response) => {
                     expect(response.body.articles.length).toBe(0)
@@ -329,6 +381,22 @@ describe("/api/articles", () => {
                 .expect(404)
                 .then((response) => {
                     expect(response.body.message).toBe("Not found")
+                })
+            })
+            test("400: Responds with bad request when given an invalid limit", () => {
+                return request(app)
+                .get("/api/articles?limit=invalid_limit")
+                .expect(400)
+                .then((response) => {
+                    expect(response.body.message).toBe("Bad request")
+                })
+            })
+            test("400: Responds with bad request when given an invalid page number", () => {
+                return request(app)
+                .get("/api/articles?p=invalid_page_number")
+                .expect(400)
+                .then((response) => {
+                    expect(response.body.message).toBe("Bad request")
                 })
             })
         })
@@ -726,7 +794,7 @@ describe("/api/comments/:comment_id", () => {
                 expect(response.body.message).toBe("Bad request")
             })
         })
-        test("400: Returns a bad request message if article_id is invalid", () => {
+        test("400: Returns a bad request message if comment_id is invalid", () => {
             return request(app)
             .patch("/api/comments/invalid_id")
             .send({inc_votes: 4})
@@ -735,7 +803,7 @@ describe("/api/comments/:comment_id", () => {
                 expect(response.body.message).toBe("Bad request")
             })
         })
-        test("404: Returns a not found message if article_id is invalid", () => {
+        test("404: Returns a not found message if comment_id is valid but doesn't exist", () => {
             return request(app)
             .patch("/api/comments/628")
             .send({inc_votes: 4})

--- a/controllers/articles-controller.js
+++ b/controllers/articles-controller.js
@@ -1,4 +1,5 @@
-const { fetchArticleById, fetchAllArticles, incrementArticleVoteCount, uploadNewArticle } = require("../models/articles-model")
+const { fetchArticleById, fetchArticles, incrementArticleVoteCount, uploadNewArticle } = require("../models/articles-model")
+const { fetchAllTopics } = require("../models/topics-model")
 
 function getArticleById(request, response, next){
     fetchArticleById(request.params.article_id).then((article) => {
@@ -8,9 +9,27 @@ function getArticleById(request, response, next){
     })
 }
 
-function getAllArticles(request, response, next){
-    fetchAllArticles(request.query.sort_by, request.query.order, request.query.topic).then((articles) => {
-        response.status(200).send({articles})
+function getArticles(request, response, next){
+    const topicName = request.query.topic
+    const promises = [fetchArticles(request.query.sort_by, request.query.order, topicName, request.query.limit, request.query.p)]
+    if(topicName){
+        promises.push(fetchAllTopics())
+    }
+    Promise.all(promises).then((result) => {
+        if(topicName){
+            let validTopic = false
+            for(const topic of result[1]){
+                if(topic.slug === topicName){
+                    validTopic = true
+                    break
+                }
+            }
+            if(validTopic === false){
+                return Promise.reject({status: 404, message: "Not found"})
+            }
+        }
+        
+        response.status(200).send({articles: result[0]})
     }).catch((err) => {
         next(err)
     })
@@ -32,4 +51,4 @@ function postNewArticle(request, response, next){
     })
 }
 
-module.exports = { getArticleById, getAllArticles, patchArticleVoteCount, postNewArticle }
+module.exports = { getArticleById, getArticles, patchArticleVoteCount, postNewArticle }

--- a/controllers/topics-controller.js
+++ b/controllers/topics-controller.js
@@ -1,8 +1,8 @@
-const { retrieveAllTopics } = require("../models/topics-model")
+const { fetchAllTopics } = require("../models/topics-model")
 
 
 function getAllTopics(request, response, next){
-    retrieveAllTopics().then((topics) => {
+    fetchAllTopics().then((topics) => {
         response.status(200).send({topics})
     }).catch((err) => {
         next(err)

--- a/endpoints.json
+++ b/endpoints.json
@@ -11,7 +11,12 @@
   },
   "GET /api/articles": {
     "description": "serves an array of all articles",
-    "queries": ["author", "topic", "sort_by", "order"],
+    "queries": {
+      "topic": "Get articles corresponding to a given topic",
+      "sort_by": "Sort by a given category (defaults to created_at)",
+      "order": "Decide whether to sort in ascending or descending order (defaults to descending order)",
+      "limit": "Limits the number of articles given",
+      "p": "Start at the given page number"},
     "exampleResponse": {
       "articles": [
         {

--- a/models/topics-model.js
+++ b/models/topics-model.js
@@ -1,9 +1,9 @@
 const db = require("../db/connection.js")
 
-function retrieveAllTopics(){
+function fetchAllTopics(){
     return db.query("SELECT * FROM topics").then((data) => {
         return data.rows
     })
 }
 
-module.exports = { retrieveAllTopics }
+module.exports = { fetchAllTopics }

--- a/routers/articles-router.js
+++ b/routers/articles-router.js
@@ -1,10 +1,10 @@
 const express = require("express")
-const { getAllArticles, getArticleById, patchArticleVoteCount, postNewArticle } = require("../controllers/articles-controller")
+const { getArticles, getArticleById, patchArticleVoteCount, postNewArticle } = require("../controllers/articles-controller")
 const { getCommentsByArticleId, postCommentToArticle } = require("../controllers/comments-controller")
 const router = express.Router()
 
 router.route("/")
-.get(getAllArticles)
+.get(getArticles)
 .post(postNewArticle)
 
 router.route("/:article_id/comments")


### PR DESCRIPTION
Also refactored getArticles() and fetchArticles() so that the topic query is in the controller, not the model.

Note: I wasn't entirely sure on what to do if a given page has no articles on it (e.g. if the limit is 10, page number is 3, but there's only 13 articles, there would be no articles on page 3), so the behaviour I settled on was just to respond with an empty array to indicate this. I was also considering either looping back to the start (so page 3 would go back to page 1, page 4 would go back to page 2 etc.), or throwing a 404 error. I think, for either of those two options, I'd need to make an extra query somewhere so I can get the length of the entire articles table and use that to help calculate what the maximum page count would be?